### PR TITLE
[iOS] Removes deprecated parameter + Fix app crashing

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -6,7 +6,6 @@ export default function prompt(
     title: ?string,
     message?: ?string,
     callbackOrButtons?: ?((text: string) => void) | Object,
-    options?: Object
 ): void {
-    AlertIOS.prompt(title, message, callbackOrButtons, options.type, options.defaultValue);
+    AlertIOS.prompt(title, message, callbackOrButtons);
 };


### PR DESCRIPTION
The `options` parameter is currently required by this lib because it's doing `options.type` but `options` is `undefined` by default, so the app crashes. Passing a `{}` is the current workaround.

This parameter was deprecated so it makes sense to  just remove it.