### PR TITLE
Turning off suggestions for the dialog's editbox

### DIFF
--- a/android/src/main/java/im/shimo/react/prompt/RNPromptFragment.java
+++ b/android/src/main/java/im/shimo/react/prompt/RNPromptFragment.java
@@ -1,6 +1,7 @@
 package im.shimo.react.prompt;
 
 
+import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
@@ -52,6 +53,7 @@ public class RNPromptFragment extends DialogFragment implements DialogInterface.
         mListener = null;
     }
 
+    @SuppressLint("ValidFragment")
     public RNPromptFragment(@Nullable RNPromptModule.PromptFragmentListener listener, Bundle arguments) {
         mListener = listener;
         setArguments(arguments);

--- a/android/src/main/java/im/shimo/react/prompt/RNPromptFragment.java
+++ b/android/src/main/java/im/shimo/react/prompt/RNPromptFragment.java
@@ -97,11 +97,11 @@ public class RNPromptFragment extends DialogFragment implements DialogInterface.
         if (arguments.containsKey(ARG_TYPE)) {
             switch (typeString) {
                 case "secure-text":
-                    type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD;
+                    type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS;
                     break;
                 case "plain-text":
                 default:
-                    type = InputType.TYPE_CLASS_TEXT;
+                    type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS;
             }
         }
 


### PR DESCRIPTION
We have found the suggestions in the edit box to be not as good of a user experience for the limited space and typical things input in a dialog popup, and propose turning off suggestions for the edit box. 