### PR TITLE
createJSModules removed in React Native 0.47

### DIFF
--- a/android/src/main/java/im/shimo/react/prompt/RNPromptPackage.java
+++ b/android/src/main/java/im/shimo/react/prompt/RNPromptPackage.java
@@ -23,7 +23,7 @@ public class RNPromptPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
+    // Removed in RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
https://github.com/facebook/react-native/releases/tag/v0.47.0