### PR TITLE
Updated RNPromptFragment.java to use androidx

### DIFF
--- a/android/src/main/java/im/shimo/react/prompt/RNPromptFragment.java
+++ b/android/src/main/java/im/shimo/react/prompt/RNPromptFragment.java
@@ -5,11 +5,12 @@ import android.app.DialogFragment;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
-import android.support.v7.app.AlertDialog;
+import androidx.core.app.NotificationCompat;
 import android.text.InputType;
 import android.view.LayoutInflater;
 import android.view.WindowManager;
 import android.widget.EditText;
+import androidx.appcompat.app.AlertDialog;
 
 import javax.annotation.Nullable;
 


### PR DESCRIPTION
Changed:
'import android.support.v7.app.AlertDialog;' to 'import androidx.core.app.NotificationCompat;' 

Added: 
'import androidx.appcompat.app.AlertDialog;

to RNPromptFragment.java to bring in line with AndroidX standard.