### PR TITLE
chore: add types to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "react-native-prompt-android",
     "version": "1.0.0",
     "description": "Polyfill for Alert.prompt on Android",
+    "types": "./index.d.ts",
     "repository": {
         "type": "git",
         "url": "https://github.com/shimohq/react-native-prompt-android"


### PR DESCRIPTION
added `types` to `package.json`, so that when the package is imported, it knows where to look for type annotations.